### PR TITLE
money_format doesn't exist on windows and substitute

### DIFF
--- a/Twig/Extension/CommerceExtension.php
+++ b/Twig/Extension/CommerceExtension.php
@@ -77,6 +77,19 @@ class CommerceExtension extends \Twig_Extension
             case '%' : $right = ' %'; break;
         }
 
-        return $left . money_format('%i', $amount) . $right;
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        /********************************* money_format not available on windows systems */
+		//This is a server using Windows : money_format replacement.
+        setlocale(LC_ALL, ''); // Locale will be different on each system.
+        $locale = localeconv();
+        //$amount = 1000000.97;
+        //echo $locale['currency_symbol'],
+                         // number_format($amount, 2, $locale['decimal_point'], $locale['thousands_sep']);	
+			return $left . number_format($amount, 2, $locale['decimal_point'], $locale['thousands_sep']) . $right;
+		} else {
+			//This is a server not using Windows
+			return $left . my_money_format('%i', $amount) . $right;
+		}
+
     }
 }


### PR DESCRIPTION
The function money_format is not available on windows systems so this is a replacement.
